### PR TITLE
Add LED pins for Adafruit Fruit Jam

### DIFF
--- a/pico2/driver/config.h
+++ b/pico2/driver/config.h
@@ -102,8 +102,8 @@
 #define DISK_IO_LED_PIN PICO_DEFAULT_LED_PIN
 #define DISK_IO_LED_ACTIVE 0
 // Per TheKitty mini-IBM PC build, pins on the Fruit Jam pin header for disk io
-#define DISK_IO_FD_LED_PIN  10
-#define DISK_IO_ATA_PRI_LED_PIN 9
+#define DISK_IO_FD_LED_PIN  7
+#define DISK_IO_ATA_PRI_LED_PIN 6
 
 #define DEFAULT_I2C_CLOCK 100000
 


### PR DESCRIPTION
Add pin 10 for green HD LED and red floppy LED for Fruit Jam corresponding to TheKitty's mini-IBM Build